### PR TITLE
Add callback url in config

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ class Website {
         passport.use(new Strategy({
             clientID: this.config.bot.id,
             clientSecret: this.config.bot.secret,
-            callbackURL: `${this.config.bot.url}:${this.app.get('port')}/auth/login`,
+            callbackURL: this.config.bot.callback_url,
             scope: ['identify', 'guilds']
         }, (accessToken, refreshToken, profile, done) => {
             process.nextTick(function() {

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
 		"secret": "",
 		"status": "online",
 		"token": "",
-		"url": "http://localhost"
+		"callback_url": "http://localhost:3000/auth/login"
 	},
 	"app": {
 		"port": 3000


### PR DESCRIPTION
Closes #11
Users have to specify the url for the callback, because they are able to have a custom domain, without the port in the url